### PR TITLE
Added filter to $wp->query_vars['url']

### DIFF
--- a/oembed-provider.php
+++ b/oembed-provider.php
@@ -47,7 +47,7 @@ class OembedProvider {
       return;
     }
 
-    $post_ID = url_to_postid($wp->query_vars['url']);
+    $post_ID = url_to_postid( apply_filters( 'oembed_url', $wp->query_vars['url'] ) );
     $post = get_post($post_ID);
 
     if(!$post) {


### PR DESCRIPTION
In some cases the $wp->query_vars[‘url’] provides the wrong url for the
embed, for example, when .htaccess is used to generate custom urls. This causes a 'not found' on oemed links. 

Provided a filter so people can override the url if they need to.

We then made a filter function to convert the url to the right wordpress permalink so that the oembed links work. 
